### PR TITLE
Text highlight bug

### DIFF
--- a/src/components/Text/index.tsx
+++ b/src/components/Text/index.tsx
@@ -63,7 +63,7 @@ function Text() {
 			childClicked.current.style.color = defaultTextColor;
 			childClicked.current.style.textDecoration = "none";
 		}
-		setChildClicked(newChildClicked);
+		setChildClicked({...newChildClicked});
 	}
 
 	const overwriteStyle: any = mapValidULBSettings(ULBSettings).verseStyles;

--- a/src/components/Text/index.tsx
+++ b/src/components/Text/index.tsx
@@ -33,7 +33,7 @@ function Text() {
 		}
 	}, [verses]);
 
-	// color back to default.
+	// Update style of clicked phrase based on if the Greek words model/dialog is open. 
 	useEffect(() => {
 		if (childClicked?.current?.style?.color !== undefined) {
 			if (showGreekWords) {
@@ -58,7 +58,7 @@ function Text() {
 	}
 
 	function handleChildClicked(newChildClicked: any) {
-		// If child was clicked, reset it's style to default. 
+		// If child was clicked, reset style to default. 
 		if (childClicked?.current?.style?.color !== undefined) {
 			childClicked.current.style.color = defaultTextColor;
 			childClicked.current.style.textDecoration = "none";

--- a/src/components/Text/index.tsx
+++ b/src/components/Text/index.tsx
@@ -35,8 +35,11 @@ function Text() {
 
 	// color back to default.
 	useEffect(() => {
-		if (!showGreekWords) {
-			if (childClicked?.current?.style?.color !== undefined) {
+		if (childClicked?.current?.style?.color !== undefined) {
+			if (showGreekWords) {
+				childClicked.current.style.color = highlightColor;
+				childClicked.current.style.textDecoration = "underline";
+			} else {
 				childClicked.current.style.color = defaultTextColor;
 				childClicked.current.style.textDecoration = "none";
 			}
@@ -54,19 +57,12 @@ function Text() {
 		setChildClicked({});
 	}
 
-	function highlightSelectedPhrase(newChildClicked: any) {
+	function handleChildClicked(newChildClicked: any) {
+		// If child was clicked, reset it's style to default. 
 		if (childClicked?.current?.style?.color !== undefined) {
 			childClicked.current.style.color = defaultTextColor;
 			childClicked.current.style.textDecoration = "none";
 		}
-		if (newChildClicked?.current?.style?.color !== undefined) {
-			newChildClicked.current.style.color = highlightColor;
-			newChildClicked.current.style.textDecoration = "underline";
-		}
-	}
-
-	function handleChildClicked(newChildClicked: any) {
-		highlightSelectedPhrase(newChildClicked);
 		setChildClicked(newChildClicked);
 	}
 


### PR DESCRIPTION
Fixes bug where childClicked state is updated before showGreekWords. This caused the program to think that the Greek words model/dialog was being closed (since showGreekWords is still false).

Now we restore the previously clicked element's style to default on new element click, and update the newly clicked element's style once showGreekWords is true.